### PR TITLE
Fix DISPATCH_SCORE_PER_CATEGORY env default (string, not number)

### DIFF
--- a/src/config/env.js
+++ b/src/config/env.js
@@ -81,7 +81,7 @@ const envSchema = z.object({
     .string()
     .transform(Number)
     .pipe(z.number().min(1))
-    .default(8),
+    .default('8'),
   GEMINI_API_KEY: z.string().optional(),
   // Default Gemini model the Writer's Room router falls back to when a
   // prompt's meta.json doesn't specify one. Per-prompt model in meta.json


### PR DESCRIPTION
The schema is z.string().transform(Number); a numeric .default(8) fails validation ("Expected string, received number") when the env var is unset, crash-looping the service on boot. Use '8' to match the other DISPATCH_* vars.