### PR TITLE
Dispatch rankings: date batches by asOf so backfills land on their re…

### DIFF
--- a/scripts/diag-ranking-data.mjs
+++ b/scripts/diag-ranking-data.mjs
@@ -1,0 +1,58 @@
+// read-only data check using the SRV->direct rewrite
+import 'dotenv/config';
+import mongoose from 'mongoose';
+
+function directUri(uri) {
+  if (!uri.startsWith('mongodb+srv://')) return uri;
+  const m = uri.match(/^mongodb\+srv:\/\/([^@]+)@([^/]+)\/([^?]+)(\?.*)?$/);
+  const [, creds, host, dbName] = m;
+  const base = host.replace(/^[^.]+\./, '');
+  const prefix = host.split('.')[0];
+  const hosts = [0, 1, 2].map(i => `${prefix}-shard-00-0${i}.${base}:27017`).join(',');
+  return `mongodb://${creds}@${hosts}/${dbName}?ssl=true&replicaSet=atlas-uys7di-shard-0&authSource=admin&retryWrites=true&w=majority`;
+}
+
+await mongoose.connect(directUri(process.env.MONGODB_TKISOCIAL_URI));
+const DispatchArticle = (await import('../src/models/dispatchArticle.model.js')).default;
+const TonkaDispatchRanking = (await import('../src/models/tonkaDispatchRankings.model.js')).default;
+
+const DAY = 86400000;
+const now = Date.now();
+
+const artTotal = await DispatchArticle.countDocuments();
+const rankTotal = await TonkaDispatchRanking.countDocuments();
+console.log(`dispatch_articles total : ${artTotal}`);
+console.log(`rankings total          : ${rankTotal}\n`);
+
+// article publish-date spread
+const artBuckets = await DispatchArticle.aggregate([
+  { $match: { published_at_ms: { $ne: null } } },
+  { $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: { $toDate: '$published_at_ms' } } }, n: { $sum: 1 } } },
+  { $sort: { _id: -1 } }, { $limit: 14 },
+]);
+console.log('articles by publish day (last 14 present):');
+for (const b of artBuckets) console.log(`  ${b._id}  ${b.n}`);
+
+// rankings by created_at day + the pub_date span within each
+const rankBuckets = await TonkaDispatchRanking.aggregate([
+  { $group: {
+    _id: { $dateToString: { format: '%Y-%m-%d', date: '$created_at' } },
+    n: { $sum: 1 },
+    batches: { $addToSet: '$batch_id' },
+    minPub: { $min: '$pub_date_ms' }, maxPub: { $max: '$pub_date_ms' },
+  } },
+  { $sort: { _id: -1 } }, { $limit: 20 },
+]);
+console.log('\nrankings by created_at day:');
+for (const b of rankBuckets) {
+  const span = b.minPub ? `${new Date(b.minPub).toISOString().slice(0,10)}..${new Date(b.maxPub).toISOString().slice(0,10)}` : 'n/a';
+  console.log(`  ${b._id}  n=${b.n}  pubspan=${span}  batches=${b.batches.join(',')}`);
+}
+
+// the actual gap: rankings whose underlying article is older than 14d (would be deleted)
+const cutoff14 = now - 14 * DAY;
+const oldPubRankings = await TonkaDispatchRanking.countDocuments({ pub_date_ms: { $lt: cutoff14 } });
+console.log(`\nrankings with pub_date older than 14d (retention would delete): ${oldPubRankings}`);
+
+await mongoose.disconnect();
+process.exit(0);

--- a/scripts/fix-backfill-created-at.mjs
+++ b/scripts/fix-backfill-created-at.mjs
@@ -1,0 +1,81 @@
+// ----------------------------------------------------------------------------
+// One-off: re-date existing `backfill-YYYY-MM-DD` ranking batches so their
+// created_at reflects the day they REPRESENT (encoded in batch_id), not the day
+// the backfill script happened to run. The Daily Rankings UI groups/sorts by
+// created_at, so without this all backfilled days pile onto the run date.
+//
+// We stamp created_at = <date>T12:00:00Z  (= 7:00 AM America/Chicago, CDT),
+// matching how the real 7am cron batches display.
+//
+// No re-scoring, no token cost — pure created_at update.
+//
+// Usage (PowerShell):
+//   node scripts/fix-backfill-created-at.mjs            # DRY RUN (shows changes)
+//   node scripts/fix-backfill-created-at.mjs --go       # apply
+// ----------------------------------------------------------------------------
+
+import 'dotenv/config';
+import mongoose from 'mongoose';
+
+const GO = process.argv.includes('--go');
+
+// Node can't resolve SRV on this machine — rewrite to direct multi-host.
+function directUri(uri) {
+  if (!uri.startsWith('mongodb+srv://')) return uri;
+  const m = uri.match(/^mongodb\+srv:\/\/([^@]+)@([^/]+)\/([^?]+)(\?.*)?$/);
+  const [, creds, host, dbName] = m;
+  const base = host.replace(/^[^.]+\./, '');
+  const prefix = host.split('.')[0];
+  const hosts = [0, 1, 2]
+    .map(i => `${prefix}-shard-00-0${i}.${base}:27017`)
+    .join(',');
+  return `mongodb://${creds}@${hosts}/${dbName}?ssl=true&replicaSet=atlas-uys7di-shard-0&authSource=admin&retryWrites=true&w=majority`;
+}
+
+await mongoose.connect(directUri(process.env.MONGODB_TKISOCIAL_URI));
+const TonkaDispatchRanking = (
+  await import('../src/models/tonkaDispatchRankings.model.js')
+).default;
+
+const BATCH_RE = /^backfill-(\d{4}-\d{2}-\d{2})$/;
+
+const batchIds = (await TonkaDispatchRanking.distinct('batch_id')).filter(b =>
+  BATCH_RE.test(b)
+);
+
+console.log(`mode: ${GO ? 'LIVE (apply)' : 'DRY RUN (no writes)'}`);
+console.log(`backfill batches found: ${batchIds.length}\n`);
+
+let totalDocs = 0;
+for (const batchId of batchIds.sort()) {
+  const date = batchId.match(BATCH_RE)[1];
+  const target = new Date(`${date}T12:00:00Z`); // 7:00 AM America/Chicago (CDT)
+
+  const docs = await TonkaDispatchRanking.find({ batch_id: batchId }).select(
+    'created_at'
+  );
+  const wrong = docs.filter(
+    d => d.created_at?.toISOString() !== target.toISOString()
+  ).length;
+  const sampleBefore = docs[0]?.created_at?.toISOString() ?? 'n/a';
+
+  console.log(
+    `  ${batchId}  docs=${docs.length} needFix=${wrong}  ${sampleBefore} -> ${target.toISOString()}`
+  );
+  totalDocs += docs.length;
+
+  if (GO && wrong > 0) {
+    await TonkaDispatchRanking.updateMany(
+      { batch_id: batchId },
+      { $set: { created_at: target } }
+    );
+  }
+}
+
+console.log(
+  `\n${GO ? 'Updated' : 'Would update'} created_at across ${batchIds.length} batches / ${totalDocs} docs.`
+);
+if (!GO) console.log('Re-run with --go to apply.');
+
+await mongoose.disconnect();
+process.exit(0);

--- a/src/services/dispatchRanking.service.js
+++ b/src/services/dispatchRanking.service.js
@@ -413,7 +413,7 @@ function pickResults(shortlist) {
 
 // ── Step 4: Save to DB ────────────────────────────────────────────────────────
 
-async function saveRankings(finalRankings, articleMap, batchId) {
+async function saveRankings(finalRankings, articleMap, batchId, createdAt) {
   const saved = [];
   const errors = [];
 
@@ -436,6 +436,10 @@ async function saveRankings(finalRankings, articleMap, batchId) {
         batch_id: batchId,
         canonical_id: article.link || null,
         category: article.category || null,
+        // Date the batch by the day it represents (asOf), not insert time, so
+        // backfilled days land on their own row in the Daily Rankings UI (which
+        // groups/sorts by created_at). Live cron passes asOf=now, unchanged.
+        created_at: createdAt,
         creator: article.author || null,
         dispatch_article_id: article._id,
         feed_match_reason: 'embedded',
@@ -702,7 +706,12 @@ export async function runDailyRanking({
 
   // 5. Save.
   const id = batchId || crypto.randomUUID();
-  const { errors, saved } = await saveRankings(finalRankings, articleMap, id);
+  const { errors, saved } = await saveRankings(
+    finalRankings,
+    articleMap,
+    id,
+    new Date(asOf)
+  );
 
   // 6. Email (optional — backfill of past days runs with sendEmail=false).
   if (sendEmail) await sendDigestEmail(finalRankings, articleMap, id, asOf);


### PR DESCRIPTION
…al day

saveRankings now stamps created_at from the run asOf instead of insert time. The Daily Rankings UI groups/sorts by created_at, so backfilled days (run in a single pass) previously collapsed onto the run date and looked like one day. Live cron passes asOf=now, so its behavior is unchanged.

Also adds two one-off ops scripts (kept as proof / tooling):
- fix-backfill-created-at.mjs: re-dates legacy backfill-* batches from batch_id
- diag-ranking-data.mjs: read-only ranking/article retention snapshot